### PR TITLE
Add InvalidInput error class

### DIFF
--- a/Errors.js
+++ b/Errors.js
@@ -1,0 +1,8 @@
+class InvalidInput extends Error {
+    constructor(message) {
+        super("Invalid input: " + message)
+    }
+}
+
+
+module.exports = InvalidInput

--- a/validation.js
+++ b/validation.js
@@ -1,4 +1,5 @@
 const Brackets = require("./Brackets")
+const InvalidInput = require("./Errors")
 
 
 function bracketsAreBalanced(formula) {
@@ -29,7 +30,7 @@ function validate(formula) {
 
     for (const character of formula) {
         if (!Brackets.isValidBracket(character)) {
-            throw new Error("Invalid input.")
+            throw new InvalidInput(character)
         }
     }
 }

--- a/validation.test.js
+++ b/validation.test.js
@@ -1,4 +1,5 @@
 const bracketsAreBalanced = require("./validation")
+const InvalidInput = require("./Errors")
 
 
 describe("Expect bracketsAreBalanced to throw", () => {
@@ -9,11 +10,11 @@ describe("Expect bracketsAreBalanced to throw", () => {
             expect(() => bracketsAreBalanced([ "(", ")" ])).toThrow(TypeError)
         })
     })
-    describe("an Error", () => {
+    describe("an InvalidInput error", () => {
         test("for inputs with invalid characters", () => {
-            expect(() => bracketsAreBalanced("4")).toThrow(Error)
-            expect(() => bracketsAreBalanced("(4)")).toThrow(Error)
-            expect(() => bracketsAreBalanced("(4+5)")).toThrow(Error)
+            expect(() => bracketsAreBalanced("4")).toThrow(InvalidInput)
+            expect(() => bracketsAreBalanced("(4)")).toThrow(InvalidInput)
+            expect(() => bracketsAreBalanced("(4+5)")).toThrow(InvalidInput)
         })
     })
     describe("nothing", () => {


### PR DESCRIPTION
When throwing Errors, it is best practice not to use the base Error class, but instead use custom error classes that better describe the type of problem. This helps the receiver of an Error understand what exactly went wrong.