### PR TITLE
Install plugin eslint-plugin-only-warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
         "es2021": true,
         "jest": true
     },
+    "plugins": ["only-warn"],
     "extends": "eslint:recommended",
     "overrides": [
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "eslint": "^8.24.0",
+        "eslint-plugin-only-warn": "^1.0.3",
         "jest": "^29.0.3"
       }
     },
@@ -1814,6 +1815,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-only-warn": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.3.tgz",
+      "integrity": "sha512-XQOX/TfLoLw6h8ky51d29uUjXRTQHqBGXPylDEmy5fe/w7LIOnp8MA24b1OSMEn9BQoKow1q3g1kLe5/9uBTvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eslint-scope": {
@@ -5766,6 +5776,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-only-warn": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.3.tgz",
+      "integrity": "sha512-XQOX/TfLoLw6h8ky51d29uUjXRTQHqBGXPylDEmy5fe/w7LIOnp8MA24b1OSMEn9BQoKow1q3g1kLe5/9uBTvw==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "eslint": "^8.24.0",
+    "eslint-plugin-only-warn": "^1.0.3",
     "jest": "^29.0.3"
   },
   "scripts": {


### PR DESCRIPTION
We set ESLint to cause warnings for all rules set in the `.eslintrc.json` file. However, the recommended rules that ship with ESLint by default still cause errors. The installed plugin changes them to warnings, so that ESLint should not cause any errors anymore.

Please checkout the branch and run `npm install` to install the plugin on your machine. If everything went well, please integrate the branch to main.